### PR TITLE
avoid duplicate insert message to recv_queue

### DIFF
--- a/rudp.c
+++ b/rudp.c
@@ -253,7 +253,7 @@ insert_message(struct rudp *U, int id, const uint8_t *buffer, int sz) {
 		struct message *m = U->recv_queue.head;
 		struct message **last = &U->recv_queue.head;
 		do {
-            if (m->id == id) { return; }
+            		if (m->id == id) { return; }
 			if (m->id > id) {
 				// insert here
 				struct message *tmp = new_message(U, buffer, sz);

--- a/rudp.c
+++ b/rudp.c
@@ -253,6 +253,7 @@ insert_message(struct rudp *U, int id, const uint8_t *buffer, int sz) {
 		struct message *m = U->recv_queue.head;
 		struct message **last = &U->recv_queue.head;
 		do {
+            if (m->id == id) { return; }
 			if (m->id > id) {
 				// insert here
 				struct message *tmp = new_message(U, buffer, sz);


### PR DESCRIPTION
insert_message 方法有可能插入重复 id 的消息, 导致 断言 assert(m->id >= id); 为 false